### PR TITLE
[Refactor] 채팅 기능 개선 및 성공 혹은 실패 시 toast 적용

### DIFF
--- a/backend/src/main/java/com/project/ssm/chat/service/MessageService.java
+++ b/backend/src/main/java/com/project/ssm/chat/service/MessageService.java
@@ -46,13 +46,15 @@ public class MessageService {
     private String secretKey;
 
 
-
     @KafkaListener(topicPattern = "chat-room-.*")
     public void consumeMessage(ConsumerRecord<String, Object> record) throws JsonProcessingException {
         log.info("consume-message : {}", record.value());
         log.info("key : {}", record.key());
-        SendMessageReq message = objectMapper.readValue(record.value().toString(), SendMessageReq.class);
-        messagingTemplate.convertAndSend("/sub/room/" + message.getChatRoomId(), message);
+        String message = objectMapper.writeValueAsString(record.value());
+        SendMessageReq sendMessageReq = objectMapper.readValue(message, SendMessageReq.class);
+
+        log.info("convert message : {}", message);
+        messagingTemplate.convertAndSend("/sub/room/" + sendMessageReq.getChatRoomId(), sendMessageReq);
     }
 
     public void sendMessage(String chatRoomId, SendMessageReq sendMessageDto) {

--- a/frontend/src/components/SidebarComponent.vue
+++ b/frontend/src/components/SidebarComponent.vue
@@ -30,7 +30,7 @@
                 </div>
                 <div class="flex justify-content-end gap-2">
                     <Button class="button-cancel" type="button" label="취소하기" severity="secondary" @click="visible = false"></Button>
-                    <Button class="button-create" type="button" label="생성하기" @click="createChatRoom"></Button>
+                    <Button class="button-create" type="button" label="생성하기" @click="createNewChatRoom"></Button>
                 </div>
             </Dialog>
           </div>
@@ -79,9 +79,6 @@ import InputText from "primevue/inputtext";
 import { useChatRoomStore } from "@/stores/useChatRoomStore";
 import { mapStores } from "pinia";
 import { useMainStore } from "@/stores/useMainStore";
-import axios from "axios";
-
-const backend = process.env.VUE_APP_API_ENDPOINT
 
 export default {
   name: "SidebarComponent",
@@ -114,20 +111,8 @@ export default {
     addMember(memberId) {
       this.memberList.push(memberId);
     },
-    async createChatRoom() {
-      const roomInfo = {
-        chatRoomName: this.chatRoomName,
-        memberId: this.memberList
-      };
-      const token = localStorage.getItem('accessToken');
-      console.log(token);
-      let response = await axios.post(`${backend}/chat/room/create`, roomInfo, {
-        headers: {
-          Authorization: token,
-        }
-      });
-      console.log(response.data);
-
+    createNewChatRoom() {
+      this.chatRoomStore.createChatRoom(this.chatRoomName, this.memberList);
       this.visible = false;
     },
   },

--- a/frontend/src/pages/MainPage.vue
+++ b/frontend/src/pages/MainPage.vue
@@ -108,8 +108,6 @@ import FullCalendarComponent from '@/components/FullCalendarComponent.vue';
 import FilterComponent from '@/components/FilterComponent.vue';
 import MeetingRoomComponent from "@/components/MeetingRoomComponent.vue";
 
-import SockJS from "sockjs-client";
-import Stomp from "webstomp-client";
 import defaultImage from "../assets/basic_profile.jpg";
 
 import { mapStores } from "pinia";
@@ -145,28 +143,15 @@ export default {
       isFilterVisible: true,
     }
   },
-  created() {
-    console.log("============기본 연결================");
-    const stompClient = this.initSock();
-    this.basicConnect(stompClient);
-  },
   computed: {
     ...mapState(useMessageStore, ['getAllMessage']),
-    ...mapStores(useMainStore, useMessageStore)
+    ...mapStores(useMainStore, useMessageStore, useStompStore)
   },
   methods: {
-    ...mapActions(useStompStore, ['basicConnect']),
     ...mapActions(useStompStore, ['roomConnect']),
     ...mapActions(useChatRoomStore, ['getRoomList']),
     getDefaultImage(e) {
       e.target.src = defaultImage;
-    },
-    initSock() {
-      const server = `${backend}/chat`
-      console.log(`소켓 연결을 시도 중 서버 주소: ${server}`)
-      let socket = new SockJS(server);
-      this.stompClient = Stomp.over(socket);
-      return this.stompClient;
     },
     sendMessage(e) {
       this.message = $('#summernote').summernote('code')
@@ -177,19 +162,17 @@ export default {
       }
     },
     send(message) {
-      if (this.stompClient && this.stompClient.connected) {
-        const msg = {
-          chatRoomId: this.$route.params.roomId,
-          memberId: this.memberId,
-          memberName: this.memberName,
-          message: message
-        };
-        this.stompClient.send("/send/room/" + this.$route.params.roomId, JSON.stringify(msg), {});
-        this.$nextTick(() => {
-          let message = this.$refs.getAllMessage;
-          message.scrollTo(0, message.scrollHeight);
-        });
-      }
+      const msg = {
+        chatRoomId: this.$route.params.roomId,
+        memberId: this.memberId,
+        memberName: this.memberName,
+        message: message
+      };
+      this.stompStore.chatStomp.send("/send/room/" + this.$route.params.roomId, JSON.stringify(msg), {});
+      this.$nextTick(() => {
+        let message = this.$refs.getAllMessage;
+        message.scrollTo(0, message.scrollHeight);
+      });
     },
     showChatting() {
       if (localStorage.getItem("chatRoomId") !== null) {

--- a/frontend/src/stores/useChatRoomStore.js
+++ b/frontend/src/stores/useChatRoomStore.js
@@ -1,9 +1,12 @@
 import { defineStore } from "pinia";
 import axios from "axios";
 import { useRouter } from "vue-router";
+import { toast } from 'vue3-toastify';
+import 'vue3-toastify/dist/index.css';
 
 const backend = process.env.VUE_APP_API_ENDPOINT;
 const storedToken = localStorage.getItem("accessToken");
+const timeout = 10000;
 
 export const useChatRoomStore = defineStore("chatRoom", {
     state: () => ({
@@ -12,6 +15,32 @@ export const useChatRoomStore = defineStore("chatRoom", {
         chatRoomId: "",
     }),
     actions: {
+        async createChatRoom(chatRoomName, memberList) {
+            const roomInfo = {
+                chatRoomName: chatRoomName,
+                memberId: memberList
+            };
+            const token = localStorage.getItem('accessToken');
+
+            try {
+                let response = await axios.post(`${backend}/chat/room/create`, roomInfo, {
+                    headers: {
+                        Authorization: token,
+                    }
+                });
+                console.log(response);
+                toast(response.data.message, {
+                    timeout: timeout
+                });
+
+            } catch (error) {
+                console.log(error);
+                toast.error(error.response.message, {
+                    timeout: timeout,
+                    // 여기에 추가 옵션을 넣을 수 있습니다.
+                })
+            }
+        },
         async getRoomList() {
             const router = useRouter();
             try {
@@ -22,11 +51,9 @@ export const useChatRoomStore = defineStore("chatRoom", {
                 });
                 if (response.data.result !== null) {
                     this.roomList = response.data.result;
-                    console.log(response.data.message);
                 }
             } catch (error) {
-                console.log(error.response.status);
-                console.log(error.response.data.message);
+                console.log(error);
                 router.push({name: 'error', params: {errorStatus: error.response.status, message: error.response.data.message}});
             }
         },

--- a/frontend/src/stores/useMainStore.js
+++ b/frontend/src/stores/useMainStore.js
@@ -1,8 +1,11 @@
 import { defineStore } from "pinia";
 import axios from "axios";
+import { toast } from 'vue3-toastify';
+import 'vue3-toastify/dist/index.css';
 
 const backend = process.env.VUE_APP_API_ENDPOINT
 const storedToken = localStorage.getItem("accessToken");
+const timeout = 10000;
 export const useMainStore = defineStore("main", {
   state: () => ({
     // 토큰 데이터 들어가는 곳
@@ -69,9 +72,16 @@ export const useMainStore = defineStore("main", {
             Authorization: localStorage.getItem('accessToken'),
           }
         })
+        toast(response.data.message, {
+          timeout: timeout
+        });
         return response.data;
       } catch (error) {
         console.log(error);
+        toast.error(error.response.data.message, {
+          timeout: timeout,
+          // 여기에 추가 옵션을 넣을 수 있습니다.
+        })
         return null;
       }
     },
@@ -111,11 +121,16 @@ export const useMainStore = defineStore("main", {
       console.log("메서드 진입")
       try {
         const response = await axios.get(backend + '/meetingroom/current');
-        console.log(response.data);
         this.meetingRooms = response.data.result;
-
+        toast(response.data.message, {
+          timeout: timeout
+        });
       } catch (error) {
         console.error('회의실 정보를 가져오지 못했습니다:', error);
+        toast.error(error.response.data.message, {
+          timeout: timeout,
+          // 여기에 추가 옵션을 넣을 수 있습니다.
+        })
       }
     },
 
@@ -124,8 +139,15 @@ export const useMainStore = defineStore("main", {
       try {
         const response = await axios.get(backend + '/member/read');
         this.members = response.data.result;
+        toast(response.data.message, {
+          timeout: timeout
+        });
       } catch (error) {
         console.error('멤버 정보를 가져오지 못했습니다:', error);
+        toast.error(error.response.data.message, {
+          timeout: timeout,
+          // 여기에 추가 옵션을 넣을 수 있습니다.
+        })
       }
     },
     async getProfileImage() {
@@ -135,10 +157,20 @@ export const useMainStore = defineStore("main", {
       this.member.profileImage = response.data[0].imageAddr;
     },
     async getChatProfile(memberId) {
-      const response = await axios.post(backend + '/member/profile', {
-        memberId: memberId
-      })
-      return response.data[0].imageAddr;
+      try {
+        const response = await axios.post(backend + '/member/profile', {
+          memberId: memberId
+        })
+        toast(response.data.message, {
+          timeout: timeout
+        });
+        return response.data[0].imageAddr;
+      } catch (error) {
+        toast.error(error.response.data.message, {
+          timeout: timeout,
+          // 여기에 추가 옵션을 넣을 수 있습니다.
+        })
+      }
     },
 
     // 멤버찾기 컴포넌트 open, close
@@ -152,8 +184,14 @@ export const useMainStore = defineStore("main", {
       try {
         const response = await axios.get(`${backend}/search/member/${this.searchMemberName}`);
         this.searchedMember = response.data;
+        toast(response.data.message, {
+          timeout: timeout
+        });
       } catch (error) {
-        alert("멤버를 찾을 수 없습니다.")
+        toast.error(error.response.data.message, {
+          timeout: timeout,
+          // 여기에 추가 옵션을 넣을 수 있습니다.
+        })
       }
     },
 

--- a/frontend/src/stores/useMemberStore.js
+++ b/frontend/src/stores/useMemberStore.js
@@ -5,6 +5,7 @@ import 'vue3-toastify/dist/index.css';
 
 const backend = process.env.VUE_APP_API_ENDPOINT;
 const storedToken = localStorage.getItem("accessToken");
+const timeout = 10000;
 
 export const useMemberStore = defineStore("member", {
     state: () => ({
@@ -29,10 +30,11 @@ export const useMemberStore = defineStore("member", {
                         "Content-Type": "application/json",
                     }
                 });
-                console.log(response.data);
                 localStorage.removeItem("accessToken")
                 localStorage.setItem("accessToken", "Bearer " + response.data.result.token);
-
+                toast(response.data.result.message, {
+                    timeout: timeout
+                });
                 window.location.href = "/";
             }catch(error){
                 console.log("에러 발생", error);
@@ -40,7 +42,7 @@ export const useMemberStore = defineStore("member", {
                 this.member.memberId="";
                 this.member.memberPw="";
                 toast.error(error.response.data.message, {
-                    timeout: 10000,
+                    timeout: timeout,
                     // 여기에 추가 옵션을 넣을 수 있습니다.
                 })
             }          
@@ -48,13 +50,13 @@ export const useMemberStore = defineStore("member", {
         async signup(){
             if(this.checkId === false){
                 toast.error("아이디 중복체크를 하세요", {
-                    timeout: 10000,
+                    timeout: timeout,
                     // 여기에 추가 옵션을 넣을 수 있습니다.
                 })
             }
             if(this.member.memberPw !== this.member.memberPwChecked){
                 toast.error("새롭게 입력하신 비밀번호가 서로 다릅니다.", {
-                    timeout: 10000,
+                    timeout: timeout,
                     // 여기에 추가 옵션을 넣을 수 있습니다.
                 })
             }
@@ -69,7 +71,6 @@ export const useMemberStore = defineStore("member", {
 
                 let formData = new FormData();
                 let json = JSON.stringify(signupMember);
-                console.log(json)
                 formData.append(
                     "member",
                     new Blob([json], { type: "application/json" })
@@ -89,7 +90,7 @@ export const useMemberStore = defineStore("member", {
 
                 }catch(error){
                     toast.error(error.response.data.message, {
-                        timeout: 10000,
+                        timeout: timeout,
                         // 여기에 추가 옵션을 넣을 수 있습니다.
                     })
                 }
@@ -104,15 +105,12 @@ export const useMemberStore = defineStore("member", {
 
                 let formData = new FormData();
                 let json = JSON.stringify(changeInfoMember);
-                console.log(json)
                 formData.append(
                     "member",
                     new Blob([json], { type: "application/json" })
                 );
                 
                 formData.append("profileImage", this.member.profileImage);
-                console.log(this.member.profileImage);
-
                 try{
                     let response = await axios.patch(backend + "/member/update", formData, {
                         headers:{
@@ -124,19 +122,17 @@ export const useMemberStore = defineStore("member", {
                     localStorage.setItem("toastMessage", response.data.message);                 
                     
                     window.location.href = "/login";
-
-                       
                 }catch(error){
                     if(error.response.data.code === "MEMBER_016" || error.response.data.code === "MEMBER_036"){
                         toast.error(error.response.data.message, {
-                            timeout: 10000,
+                            timeout: timeout,
                             // 여기에 추가 옵션을 넣을 수 있습니다.
                         })
                     }    
                 }
             }else{
                 toast.error("새롭게 입력하신 비밀번호가 서로 다릅니다.", {
-                    timeout: 10000,
+                    timeout: timeout,
                     // 여기에 추가 옵션을 넣을 수 있습니다.
                 })
             }
@@ -146,7 +142,7 @@ export const useMemberStore = defineStore("member", {
             const toastMessage = localStorage.getItem("toastMessage");
             if (toastMessage) {
               toast(toastMessage, {
-                timeout: 10000,
+                timeout: timeout,
                 // 여기에 추가적인 toast 옵션을 설정할 수 있습니다.
               });
               localStorage.removeItem("toastMessage"); // 메시지를 표시한 후에는 삭제
@@ -160,14 +156,14 @@ export const useMemberStore = defineStore("member", {
             try {
               const response = await axios.post(backend + '/member/check/id', req);
               toast(response.data.message, {
-                timeout: 10000,
+                timeout: timeout,
                 // 여기에 추가 옵션을 넣을 수 있습니다.
             })
                 this.checkId = true;
 
             } catch (error) {
                 toast.error(error.response.data.message, {
-                    timeout: 10000,
+                    timeout: timeout,
                     // 여기에 추가 옵션을 넣을 수 있습니다.
                 })
                 this.checkId = false;

--- a/frontend/src/stores/useMessageStore.js
+++ b/frontend/src/stores/useMessageStore.js
@@ -1,8 +1,11 @@
 import { defineStore } from "pinia";
 import axios from "axios";
 import { useMainStore } from "@/stores/useMainStore";
+import { toast } from 'vue3-toastify';
+import 'vue3-toastify/dist/index.css';
 
 const backend = process.env.VUE_APP_API_ENDPOINT;
+const timeout = 10000;
 export const useMessageStore = defineStore("message", {
     state: () => ({
         recvList: [],
@@ -32,6 +35,10 @@ export const useMessageStore = defineStore("message", {
                      })
                  } catch (error) {
                     console.log(error);
+                     toast.error(error.response.data.message, {
+                         timeout: timeout,
+                         // 여기에 추가 옵션을 넣을 수 있습니다.
+                     })
                  }
              }
         },

--- a/frontend/src/stores/useStompStore.js
+++ b/frontend/src/stores/useStompStore.js
@@ -3,72 +3,17 @@ import SockJS from "sockjs-client";
 import Stomp from "webstomp-client";
 import { useMessageStore } from "@/stores/useMessageStore";
 import { useRouter } from "vue-router";
+// import { toast } from 'vue3-toastify';
+// import 'vue3-toastify/dist/index.css';
 
 const backend = process.env.VUE_APP_API_ENDPOINT;
+// const timeout = 10000;
 
 export const useStompStore = defineStore("stomp", {
+    state: () => ({
+        chatStomp: {}
+    }),
     actions: {
-        basicConnect(stompClient) {
-            const router = useRouter();
-            console.log("================store============")
-            console.log(stompClient);
-            if (stompClient.ws.readyState === 0) {
-                console.log("============기본 연결================");
-                stompClient.connect(
-                    {},
-                    frame => {
-                        this.connected = true;
-                        console.log('소켓 연결 성공', frame);
-                        stompClient.subscribe("/sub/room", res => {
-                            console.log("구독으로 받은 메시지입니다.", res.body);
-                            useMessageStore().addMessage(JSON.parse(res.body));
-                        });
-                    },
-                    error => {
-                        stompClient.ws.readyState = 0;
-                        this.connected = false;
-                        console.log('소켓 연결 실패', error);
-                        if (error.code === 1001) {
-                            console.log('=======재접속========');
-                            let retry = 0;
-                            if (retry < 3) {
-                                setTimeout(() => {
-                                    console.log('접속을 재시도 합니다.');
-                                    retry += 1;
-                                    this.basicConnect(stompClient);
-                                }, 1000 * retry);
-                            } else {
-                                router.push({name: 'error', params: {errorStatus: error.code, message: '서버가 예기치 못한 오류로 인해 종료되어 현재 채팅방에 접속할 수 없습니다.'}});
-                            }
-                        } else if (error.code === 1002) {
-                            console.log('=======재접속========');
-                            let retry = 0;
-                            if (retry < 3) {
-                                setTimeout(() => {
-                                    console.log('접속을 재시도 합니다.');
-                                    retry += 1;
-                                    this.basicConnect(stompClient);
-                                }, 1000 * retry);
-                            } else {
-                                router.push({name: 'error', params: {errorStatus: error.code, message: '서버가 예기치 못한 오류로 인해 종료되어 현재 채팅방에 접속할 수 없습니다.'}});
-                            }
-                        } else if (error.code === 1006) {
-                            console.log('=======재접속========');
-                            let retry = 0;
-                            if (retry < 3) {
-                                setTimeout(() => {
-                                    console.log('접속을 재시도 합니다.');
-                                    retry += 1;
-                                    this.basicConnect(stompClient);
-                                }, 1000 * retry);
-                            } else {
-                                router.push({name: 'error', params: {errorStatus: error.code, message: '서버가 예기치 못한 오류로 인해 종료되어 현재 채팅방에 접속할 수 없습니다.'}});
-                            }
-                        }
-                    }
-                )
-            }
-        },
         roomConnect(chatRoomId, token) {
             const router = useRouter();
             const server = `${backend}/chat`
@@ -110,14 +55,10 @@ export const useStompStore = defineStore("stomp", {
                     }
                 }
             )
+            this.chatStomp = this.stompClient;
             socket.onclose = function (event) {
                 console.log(event.wasClean);
                 console.log(event);
-                if (event.code === 4000) {
-                    alert("채팅방 연결이 끊어졌습니다. 다시 연결을 시도해주세요");
-                    window.location.href = '/';
-                }
-
                 if (event.code === 1001) {
                     console.log('=======재접속========');
                     let retry = 0;


### PR DESCRIPTION
- 카프카 메시지 브로커로 메시지를 보낼 때 타입이 안 맞는 문제 해결
- 메인 페이지에서 소켓을 열어서 중복이 되는 문제 해결
- 전체적인 axios 응답 결과를 toast로 보여지게 수정
- 메인 페이지에서 중복으로 소켓 여는 부분을 제거하고 store에서 stomp client를 받아와서 사용하게 변경